### PR TITLE
php 8.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['7.4', '8.1']
+        php: ['7.4', '8.1', '8.2']
 
     name: PHP ${{ matrix.php }}
 

--- a/lib/classes/Swift/Attachment.php
+++ b/lib/classes/Swift/Attachment.php
@@ -27,7 +27,7 @@ class Swift_Attachment extends Swift_Mime_Attachment
     public function __construct($data = null, $filename = null, $contentType = null)
     {
         \call_user_func_array(
-            [$this, 'Swift_Mime_Attachment::__construct'],
+            'Swift_Mime_Attachment::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('mime.attachment')
             );

--- a/lib/classes/Swift/EmbeddedFile.php
+++ b/lib/classes/Swift/EmbeddedFile.php
@@ -27,7 +27,7 @@ class Swift_EmbeddedFile extends Swift_Mime_EmbeddedFile
     public function __construct($data = null, $filename = null, $contentType = null)
     {
         \call_user_func_array(
-            [$this, 'Swift_Mime_EmbeddedFile::__construct'],
+            'Swift_Mime_EmbeddedFile::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('mime.embeddedfile')
             );

--- a/lib/classes/Swift/FailoverTransport.php
+++ b/lib/classes/Swift/FailoverTransport.php
@@ -23,7 +23,7 @@ class Swift_FailoverTransport extends Swift_Transport_FailoverTransport
     public function __construct($transports = [])
     {
         \call_user_func_array(
-            [$this, 'Swift_Transport_FailoverTransport::__construct'],
+            'Swift_Transport_FailoverTransport::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('transport.failover')
             );

--- a/lib/classes/Swift/LoadBalancedTransport.php
+++ b/lib/classes/Swift/LoadBalancedTransport.php
@@ -23,7 +23,7 @@ class Swift_LoadBalancedTransport extends Swift_Transport_LoadBalancedTransport
     public function __construct($transports = [])
     {
         \call_user_func_array(
-            [$this, 'Swift_Transport_LoadBalancedTransport::__construct'],
+            'Swift_Transport_LoadBalancedTransport::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('transport.loadbalanced')
             );

--- a/lib/classes/Swift/Message.php
+++ b/lib/classes/Swift/Message.php
@@ -43,7 +43,7 @@ class Swift_Message extends Swift_Mime_SimpleMessage
     public function __construct($subject = null, $body = null, $contentType = null, $charset = null)
     {
         \call_user_func_array(
-            [$this, 'Swift_Mime_SimpleMessage::__construct'],
+            'Swift_Mime_SimpleMessage::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('mime.message')
             );

--- a/lib/classes/Swift/MimePart.php
+++ b/lib/classes/Swift/MimePart.php
@@ -27,7 +27,7 @@ class Swift_MimePart extends Swift_Mime_MimePart
     public function __construct($body = null, $contentType = null, $charset = null)
     {
         \call_user_func_array(
-            [$this, 'Swift_Mime_MimePart::__construct'],
+            'Swift_Mime_MimePart::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('mime.part')
             );

--- a/lib/classes/Swift/NullTransport.php
+++ b/lib/classes/Swift/NullTransport.php
@@ -18,7 +18,7 @@ class Swift_NullTransport extends Swift_Transport_NullTransport
     public function __construct()
     {
         \call_user_func_array(
-            [$this, 'Swift_Transport_NullTransport::__construct'],
+            'Swift_Transport_NullTransport::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('transport.null')
         );

--- a/lib/classes/Swift/SendmailTransport.php
+++ b/lib/classes/Swift/SendmailTransport.php
@@ -23,7 +23,7 @@ class Swift_SendmailTransport extends Swift_Transport_SendmailTransport
     public function __construct($command = '/usr/sbin/sendmail -bs')
     {
         \call_user_func_array(
-            [$this, 'Swift_Transport_SendmailTransport::__construct'],
+            'Swift_Transport_SendmailTransport::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('transport.sendmail')
             );

--- a/lib/classes/Swift/SmtpTransport.php
+++ b/lib/classes/Swift/SmtpTransport.php
@@ -33,7 +33,7 @@ class Swift_SmtpTransport extends Swift_Transport_EsmtpTransport
     public function __construct($host = 'localhost', $port = 25, $encryption = null)
     {
         \call_user_func_array(
-            [$this, 'Swift_Transport_EsmtpTransport::__construct'],
+            'Swift_Transport_EsmtpTransport::__construct',
             Swift_DependencyContainer::getInstance()
                 ->createDependenciesFor('transport.smtp')
         );

--- a/lib/classes/Swift/SpoolTransport.php
+++ b/lib/classes/Swift/SpoolTransport.php
@@ -26,7 +26,7 @@ class Swift_SpoolTransport extends Swift_Transport_SpoolTransport
         $arguments[] = $spool;
 
         \call_user_func_array(
-            [$this, 'Swift_Transport_SpoolTransport::__construct'],
+            'Swift_Transport_SpoolTransport::__construct',
             $arguments
         );
     }


### PR DESCRIPTION
Callables of the form [$obj, "ClassName::Method"] are deprecated.