### PR TITLE
Added composer replace to fulfil  swiftmailer/swiftmailer dependency by installing this package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "mockery/mockery": "^1.0",
         "symfony/phpunit-bridge": "^4.4|^5.4"
     },
+    "replace": {
+        "swiftmailer/swiftmailer": "^6"
+    },
     "suggest": {
         "ext-intl": "Needed to support internationalized email addresses"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "friendsofsymfony1/swiftmailer",
     "type": "library",
-    "description": "Fork of unmaingained Swiftmailer, free feature-rich PHP mailer",
+    "description": "Fork of unmaintained Swiftmailer, free feature-rich PHP mailer",
     "keywords": ["mail","mailer","email"],
     "homepage": "https://swiftmailer.symfony.com",
     "license": "MIT",


### PR DESCRIPTION
What's your opinion on this? We could either replace `swiftmailer/swiftmailer` in symfony1's `composer.json` or add the replace-tag to this `composer.json` to tell composer that `swiftmailer/swiftmailer ^6` is fulfilled by installing this package.