### PR TITLE
Fixing test deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,4 +53,3 @@ jobs:
         run: vendor/bin/simple-phpunit --verbose
         env:
           SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT: 1
-          SYMFONY_DEPRECATIONS_HELPER: weak

--- a/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/AttachmentAcceptanceTest.php
@@ -8,6 +8,7 @@ class Swift_Mime_AttachmentAcceptanceTest extends \PHPUnit\Framework\TestCase
     private $cache;
     private $headers;
     private $emailValidator;
+    private $idGenerator;
 
     protected function setUp()
     {

--- a/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/EmbeddedFileAcceptanceTest.php
@@ -8,6 +8,7 @@ class Swift_Mime_EmbeddedFileAcceptanceTest extends \PHPUnit\Framework\TestCase
     private $cache;
     private $headers;
     private $emailValidator;
+    private $idGenerator;
 
     protected function setUp()
     {

--- a/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
+++ b/tests/acceptance/Swift/Mime/MimePartAcceptanceTest.php
@@ -8,6 +8,7 @@ class Swift_Mime_MimePartAcceptanceTest extends \PHPUnit\Framework\TestCase
     private $cache;
     private $headers;
     private $emailValidator;
+    private $idGenerator;
 
     protected function setUp()
     {

--- a/tests/unit/Swift/CharacterStream/ArrayCharacterStreamTest.php
+++ b/tests/unit/Swift/CharacterStream/ArrayCharacterStreamTest.php
@@ -252,7 +252,8 @@ class Swift_CharacterStream_ArrayCharacterStreamTest extends \SwiftMailerTestCas
         $stream = new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8');
 
         $os->shouldReceive('setReadPointer')
-           ->between(0, 1)
+           ->atMost()
+           ->times(1)
            ->with(0);
         $os->shouldReceive('read')->once()->andReturn(pack('C*', 0xD0));
         $os->shouldReceive('read')->once()->andReturn(pack('C*', 0x94));
@@ -284,7 +285,8 @@ class Swift_CharacterStream_ArrayCharacterStreamTest extends \SwiftMailerTestCas
         $stream = new Swift_CharacterStream_ArrayCharacterStream($factory, 'utf-8');
 
         $os->shouldReceive('setReadPointer')
-           ->between(0, 1)
+           ->atMost()
+           ->times(1)
            ->with(0);
         $os->shouldReceive('read')->once()->andReturn(pack('C*', 0xD0));
         $os->shouldReceive('read')->once()->andReturn(pack('C*', 0x94));


### PR DESCRIPTION
This pr fixes the test deprecations for using mockery 1.6.7 and php 8.2 and re-enables the deprecation helper. Closes #8 