### PR TITLE
Add vendor name and replaces section to 5.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "swiftmailer/swiftmailer",
+    "name": "friendsofsymfony1/swiftmailer",
     "type": "library",
-    "description": "Swiftmailer, free feature-rich PHP mailer",
+    "description": "Fork of unmaintained Swiftmailer, free feature-rich PHP mailer",
     "keywords": ["mail","mailer","email"],
     "homepage": "https://swiftmailer.symfony.com",
     "license": "MIT",
@@ -12,6 +12,10 @@
         {
             "name": "Fabien Potencier",
             "email": "fabien@symfony.com"
+        },
+        {
+            "name": "FriendsOfSymfony1 Community",
+            "homepage": "https://github.com/FriendsOfSymfony1/swiftmailer/graphs/contributors"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "mockery/mockery": "~0.9.1",
         "symfony/phpunit-bridge": "~3.2"
     },
+    "replace": {
+        "swiftmailer/swiftmailer": "^5"
+    },
     "autoload": {
         "files": ["lib/swift_required.php"]
     },


### PR DESCRIPTION
Backport of https://github.com/FriendsOfSymfony1/swiftmailer/commit/438d794ae197363fd48b0c96362cd11b05bace21  and https://github.com/FriendsOfSymfony1/swiftmailer/pull/7 for 5.x branch in order to make https://github.com/FriendsOfSymfony1/swiftmailer/commit/1ed324116b44c5ba1c8fd7a9c66e6e857a649849 (which was backported to 5.x) installable.