### PR TITLE
Replace only swiftmailer/swiftmailer version ^6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/phpunit-bridge": "^7"
     },
     "replace": {
-        "swiftmailer/swiftmailer": "^6"
+        "swiftmailer/swiftmailer": "^6.3"
     },
     "suggest": {
         "ext-intl": "Needed to support internationalized email addresses"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | maybe?
| Deprecations? | no
| Fixed tickets | #24 
| License       | MIT

Adjusting this repository to replace only latest `swiftmailer/swiftmailer` versions which don't come with security issues stops versions ^6.4 to be marked as conflciting by `roave/security-advisories`

Since this technically stops replacing swiftmailer/swiftmailer versions 6.0.0 - 6.2.4 with this repo I am not sure if you'd consider this a BC break, but it should not have an effect for projects which didn't upgrade yet and the ones who did are already above those version