### PR TITLE
Replace dockage/mailcatcher with axllent/mailpit for CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       mailpit:
-        image: axllent/mailpit
+        image: axllent/mailpit:v1.30
         ports:
           - 4456:1025
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      mailcatcher:
-        image: dockage/mailcatcher:0.9.0
+      mailpit:
+        image: axllent/mailpit
         ports:
           - 4456:1025
 

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Upcoming
 * Fix deprecations for PHP 8.5 compatibility
 * Update CI pipeline to Ubuntu 22.04
 * Skip test incompatible with newer OpenSSL
+* Replace dockage/mailcatcher with axllent/mailpit for CI tests
 
 6.4.1 (2025-05-16)
 ------------------


### PR DESCRIPTION
## Summary
The [`dockage/mailcatcher`](https://github.com/dockage/mailcatcher) Docker image has been archived and is no longer maintained. This PR replaces it with [`axllent/mailpit`](https://github.com/axllent/mailpit).

## Changes
- `.github/workflows/tests.yml`: replace `dockage/mailcatcher:0.9.0` → `axllent/mailpit`
- Rename service from `mailcatcher` to `mailpit`

## Compatibility
Both tools use SMTP port 1025, so the acceptance test config (`SWIFT_SMTP_HOST`, `SWIFT_SMOKE_SMTP_PORT`) works unchanged. Host port mapping `4456:1025` stays the same.

Refs: #29