### PR TITLE
Pin GitHub Actions runner to ubuntu-24.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linux_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     services:
       mailpit:

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Upcoming
 * Update CI pipeline to Ubuntu 22.04
 * Skip test incompatible with newer OpenSSL
 * Replace dockage/mailcatcher with axllent/mailpit for CI tests
+* Pin CI runner from ubuntu-latest to ubuntu-24.04
 
 6.4.1 (2025-05-16)
 ------------------


### PR DESCRIPTION
Replace `ubuntu-latest` with the current stable version `ubuntu-24.04` to avoid unexpected changes from future `latest` updates.